### PR TITLE
📉 Reduce gas usage in value() and reclaim() functions in FTLA

### DIFF
--- a/contracts/truefi2/FixedTermLoanAgency.sol
+++ b/contracts/truefi2/FixedTermLoanAgency.sol
@@ -392,9 +392,10 @@ contract FixedTermLoanAgency is IFixedTermLoanAgency, UpgradeableClaimable {
 
         // find the token, repay loan and remove loan from loan array
         ILoanToken2[] storage _loans = poolLoans[pool];
-        for (uint256 index = 0; index < _loans.length; index++) {
+        uint256 loansLength = _loans.length;
+        for (uint256 index = 0; index < loansLength; index++) {
             if (_loans[index] == loanToken) {
-                _loans[index] = _loans[_loans.length - 1];
+                _loans[index] = _loans[loansLength - 1];
                 _loans.pop();
 
                 uint256 fundsReclaimed = _redeemAndRepay(loanToken, pool, data);


### PR DESCRIPTION
Profiling results for loan array of size 1 and 5:
- reclaim() direct calls

| | before | after |
| --- | --- | --- |
| 1 loop iteration  | 105218 | 105219 |
| 5 loop iterations | 120599 | 120201 |

- value() (borrow() calls)

| | before | after |
| --- | --- | --- |
| 1 loop iteration  | 989145 | 989901 |
| 5 loop iterations | 1142020 | 1136764 |
