### PR TITLE
💯 Add TUSD PoR decimal vuln proof of concept unit test

### DIFF
--- a/test/true-currencies/TrueCurrencyWithPoR.test.ts
+++ b/test/true-currencies/TrueCurrencyWithPoR.test.ts
@@ -137,7 +137,7 @@ describe('TrueCurrency with Proof-of-reserves check', () => {
     expect(await token.balanceOf(owner.address)).to.equal(balanceBefore)
   })
 
-  it.only('should revert if feed decimals > TrueCurrency decimals and TrueCurrency supply > proof-of-reserves', async () => {
+  it('should revert if feed decimals > TrueCurrency decimals and TrueCurrency supply > proof-of-reserves', async () => {
     const maxAmountToMint = utils.parseEther('10')
     const tooMuchToMint = utils.parseEther('1000')
 


### PR DESCRIPTION
@pkuchtatt @krzysztof-jelski While reviewing the PoR implementation for formal verification, I found a decimals vuln that we had overlooked in PR #1176.

Essentially, if `reserveDecimals > trueDecimals`, then we forget to also normalize `amount` to the correct decimals. This lets us take advantage of the order of magnitude difference to mint more than would normally be allowed. Here's an example:
```
amount: 1000 * 10^18
currentSupply: 1_000_000 * 10^18
trueDecimals: 18
reserves: 1_000_010 * 10^20
reserveDecimals: 20

currentSupply after if block: 1_000_000 * 10^20
amount after if block: 1000 * 10^18
reserves after if block: 1_000_010 * 10^20

currentSupply + amount after if block: 1_000_010 * 10^20

TUSD.totalSupply() after mint call: 1_001_000 * 10^18
```

I confirmed this with a failing unit test in this PR.

My proposal is:
if Chainlink has full authority to set the AggregatorV3Interface `decimals()`:
- let's just `require(trueDecimals == reserveDecimals)` and delete the normalization if block

else:
- we would also need to normalize `amount`

What do you think?