### PR TITLE
[A4] Remove redundant address casting

### DIFF
--- a/packages/contracts-por/contracts/TokenControllerV3.sol
+++ b/packages/contracts-por/contracts/TokenControllerV3.sol
@@ -233,15 +233,15 @@ contract TokenControllerV3 {
     */
 
     function transferTrueCurrencyProxyOwnership(address _newOwner) external onlyOwner {
-        IOwnedUpgradeabilityProxy(address(uint160(address(token)))).transferProxyOwnership(_newOwner);
+        IOwnedUpgradeabilityProxy(address(token)).transferProxyOwnership(_newOwner);
     }
 
     function claimTrueCurrencyProxyOwnership() external onlyOwner {
-        IOwnedUpgradeabilityProxy(address(uint160(address(token)))).claimProxyOwnership();
+        IOwnedUpgradeabilityProxy(address(token)).claimProxyOwnership();
     }
 
     function upgradeTrueCurrencyProxyImplTo(address _implementation) external onlyOwner {
-        IOwnedUpgradeabilityProxy(address(uint160(address(token)))).upgradeTo(_implementation);
+        IOwnedUpgradeabilityProxy(address(token)).upgradeTo(_implementation);
     }
 
     /*
@@ -590,7 +590,7 @@ contract TokenControllerV3 {
      * @dev pause all pausable actions on TrueCurrency, mints/burn/transfer/approve
      */
     function pauseToken() external virtual onlyFastPauseOrOwner {
-        IOwnedUpgradeabilityProxy(address(uint160(address(token)))).upgradeTo(PAUSED_IMPLEMENTATION);
+        IOwnedUpgradeabilityProxy(address(token)).upgradeTo(PAUSED_IMPLEMENTATION);
     }
 
     /**

--- a/packages/contracts-por/contracts/common/BurnableTokenWithBounds.sol
+++ b/packages/contracts-por/contracts/common/BurnableTokenWithBounds.sol
@@ -38,7 +38,7 @@ abstract contract BurnableTokenWithBounds is ReclaimerToken {
      * - `msg.sender` must have at least `amount` tokens.
      *
      */
-    function burn(uint256 amount) override external {
+    function burn(uint256 amount) external override {
         _burn(msg.sender, amount);
     }
 


### PR DESCRIPTION
@yuchenlintt Can you take a look at this one? We're not sure what was the purpose of `address(uint160(address(token)))` casting. Auditor hinted that _it is used to cast the address of token to a payable one_. We don't see a point in doing that though or maybe we are missing something?