### PR TITLE
Revert "🤹‍♂️ Handle reserve feeds with nonmatching decimals"

### DIFF
--- a/packages/contracts-por/contracts/TrueCurrencyWithProofOfReserve.sol
+++ b/packages/contracts-por/contracts/TrueCurrencyWithProofOfReserve.sol
@@ -29,22 +29,14 @@ abstract contract TrueCurrencyWithProofOfReserve is TrueCurrency, IProofOfReserv
             super._mint(account, amount);
             return;
         }
+        // Get required info about decimals.
+        // Decimals of the Proof of Reserve feed must be the same as the token's.
+        require(decimals() == AggregatorV3Interface(chainReserveFeed).decimals(), "TrueCurrency: Unexpected decimals of PoR feed");
 
         // Get latest proof-of-reserves from the feed
         (, int256 signedReserves, , uint256 updatedAt, ) = AggregatorV3Interface(chainReserveFeed).latestRoundData();
         require(signedReserves > 0, "TrueCurrency: Invalid answer from PoR feed");
         uint256 reserves = uint256(signedReserves);
-
-        // Get required info about total supply & decimals
-        uint8 trueDecimals = decimals();
-        uint8 reserveDecimals = AggregatorV3Interface(chainReserveFeed).decimals();
-        uint256 currentSupply = totalSupply();
-        // Normalise TrueCurrency & reserve decimals
-        if (trueDecimals < reserveDecimals) {
-            currentSupply = currentSupply.mul(10**uint256(reserveDecimals - trueDecimals));
-        } else if (trueDecimals > reserveDecimals) {
-            reserves = reserves.mul(10**uint256(trueDecimals - reserveDecimals));
-        }
 
         // Sanity check: is chainlink answer updatedAt in the past
         require(block.timestamp >= updatedAt, "TrueCurrency: invalid PoR updatedAt");
@@ -55,7 +47,7 @@ abstract contract TrueCurrencyWithProofOfReserve is TrueCurrency, IProofOfReserv
         // Get required info about total supply.
         // Check that after minting more tokens, the total supply would NOT exceed the reserves
         // reported by the latest valid proof-of-reserves feed.
-        require(currentSupply + amount <= reserves, "TrueCurrency: total supply would exceed reserves after mint");
+        require(totalSupply() + amount <= reserves, "TrueCurrency: total supply would exceed reserves after mint");
         super._mint(account, amount);
     }
 

--- a/packages/contracts-por/test/TrueUSD.test.ts
+++ b/packages/contracts-por/test/TrueUSD.test.ts
@@ -32,7 +32,6 @@ describe('TrueCurrency with Proof-of-reserves check', () => {
     [owner] = wallets
     provider = _provider
     token = (await new TrueUSD__factory(owner).deploy()) as TrueUSD
-    await token.mint(owner.address, AMOUNT_TO_MINT)
     // Deploy a mock aggregator to mock Proof of Reserve feed answers
     mockV3Aggregator = await new MockV3Aggregator__factory(owner).deploy(
       '18',
@@ -80,7 +79,7 @@ describe('TrueCurrency with Proof-of-reserves check', () => {
     expect(await token.balanceOf(owner.address)).to.equal(balanceBefore.add(AMOUNT_TO_MINT))
   })
 
-  it('should mint successfully when feed decimals < TrueCurrency decimals', async () => {
+  it('should revert mint when feed decimals < TrueCurrency decimals', async () => {
     const currentTusdSupply = await token.totalSupply()
     const validReserve = currentTusdSupply.div(exp(1, 12)).add(AMOUNT_TO_MINT)
 
@@ -94,14 +93,14 @@ describe('TrueCurrency with Proof-of-reserves check', () => {
 
     // Mint TUSD
     const balanceBefore = await token.balanceOf(owner.address)
-    await token.mint(owner.address, AMOUNT_TO_MINT, { gasLimit: 200_000 })
-    expect(await token.balanceOf(owner.address)).to.equal(balanceBefore.add(AMOUNT_TO_MINT))
+    await expect(token.mint(owner.address, AMOUNT_TO_MINT)).to.be.revertedWith('TrueCurrency: Unexpected decimals of PoR feed')
+    expect(await token.balanceOf(owner.address)).to.equal(balanceBefore)
   })
 
-  it('should mint successfully when feed decimals > TrueCurrency decimals', async () => {
+  it('should revert mint when feed decimals > TrueCurrency decimals', async () => {
     // Re-deploy a mock aggregator with more decimals
     const currentTusdSupply = await token.totalSupply()
-    const validReserve = currentTusdSupply.mul(exp(1, 2)).add(AMOUNT_TO_MINT)
+    const validReserve = currentTusdSupply.div(exp(1, 12)).add(AMOUNT_TO_MINT)
 
     const mockV3AggregatorWith20Decimals = await new MockV3Aggregator__factory(owner).deploy('20', validReserve)
     // Set feed and heartbeat on newly-deployed aggregator
@@ -112,8 +111,8 @@ describe('TrueCurrency with Proof-of-reserves check', () => {
 
     // Mint TUSD
     const balanceBefore = await token.balanceOf(owner.address)
-    await token.mint(owner.address, AMOUNT_TO_MINT, { gasLimit: 200_000 })
-    expect(await token.balanceOf(owner.address)).to.equal(balanceBefore.add(AMOUNT_TO_MINT))
+    await expect(token.mint(owner.address, AMOUNT_TO_MINT)).to.be.revertedWith('TrueCurrency: Unexpected decimals of PoR feed')
+    expect(await token.balanceOf(owner.address)).to.equal(balanceBefore)
   })
 
   it('should mint successfully when TrueCurrency supply == proof-of-reserves', async () => {


### PR DESCRIPTION
This reverts commit 6d67b3534afa40d70acb537a0466e738fc9e3260.

Reverting those changes to keep the state of `packages/contracts-por` subdir consistent with the latest Ethereum mainnet deployment of TrueUSD and TokenControllerV3 contracts (40991356a7572de7d519a52e0fe25a99d8cbc48a). 

For context, those changes turned out to not be needed as a ChainLink feed with compatible decimals has eventually been used.

There were two more PRs (#1221 and #1222) merged on top of the latest deployed version (40991356a7572de7d519a52e0fe25a99d8cbc48a). These were minor improvements that should be introduced in the future deployments of TrueUSD on Ethereum mainnet, therefore should stay in the repo.

The exact version of the code deployed has been documented in file added in PR #1235.